### PR TITLE
♻️ Improve command line argument parsing

### DIFF
--- a/pkg/config/cli_test.go
+++ b/pkg/config/cli_test.go
@@ -113,7 +113,7 @@ func TestParseFlags(t *testing.T) {
 		},
 		{
 			name: "multiple input files",
-			args: []string{"-i", "input1.md input2.md", "-o", "output.md"},
+			args: []string{"-i", "input1.md", "input2.md", "-o", "output.md"},
 			want: &CLIOptions{
 				InputFiles: []string{"input1.md", "input2.md"},
 				OutputFile: "output.md",


### PR DESCRIPTION
## Changes

- Remove dependency on flag package
- Implement custom argument parser
- Add flag constants for better maintainability
- Support multiple input files with -i flag
- Update tests to cover new parsing behavior

## Implementation Details

- Refactored argument parsing into two stages:
  1. Collect flags and their values into a map
  2. Extract values from the map to build CLIOptions

- Added constants for flag names to improve maintainability:
  - InputFilesFlag = "-i"
  - OutputFileFlag = "-o"
  - ConfigFileFlag = "-c"

- Improved handling of multiple input files after -i flag
- Updated tests to verify new parsing behavior

## Testing
- All small tests passing
- All acceptance tests passing